### PR TITLE
Add an option to skip summary

### DIFF
--- a/lib/codenarc/plugin.rb
+++ b/lib/codenarc/plugin.rb
@@ -18,7 +18,7 @@ module Danger
     # The project root, which will be used to make the paths relative.
     # Defaults to `pwd`.
     # @return   [String] project_root value
-    # attr_accessor :project_root
+    attr_accessor :project_root
     def project_root
       root = @project_root || Dir.pwd
       root += "/" unless root.end_with? "/"
@@ -28,7 +28,7 @@ module Danger
     # Defines if the test summary will be sticky or not.
     # Defaults to `false`.
     # @return   [Boolean] sticky
-    # attr_accessor :sticky_summary
+    attr_accessor :sticky_summary
     def sticky_summary
       @sticky_summary || false
     end

--- a/lib/codenarc/plugin.rb
+++ b/lib/codenarc/plugin.rb
@@ -33,6 +33,14 @@ module Danger
       @sticky_summary || false
     end
 
+    # Defines if the test summary will be skipped or not.
+    # Defaults to `false`.
+    # @return   [Boolean] skip
+    attr_accessor :skip_summary
+    def skip_summary
+      @skip_summary || false
+    end
+
     # Reads a puppet-lint summary file and reports it.
     #
     # @param    [String] file_path Path for puppet-lint report.
@@ -49,14 +57,16 @@ module Danger
       doc = Nokogiri::XML(File.open(report_file))
 
       # Create Summary
-      pkg_summary = doc.xpath("//PackageSummary")[0]
-      tf = pkg_summary.attr("totalFiles")
-      fwv = pkg_summary.attr("filesWithViolations")
-      p1_count = pkg_summary.attr("priority1")
-      p2_count = pkg_summary.attr("priority2")
-      p3_count = pkg_summary.attr("priority3")
-      summary = "CodeNarc scanned #{tf} files. Found #{fwv} files with violations. #{p1_count} P1 violations, #{p2_count} P2 violations, and #{p3_count} P3 violations"
-      message(summary, sticky: sticky_summary)
+      unless skip_summary
+        pkg_summary = doc.xpath("//PackageSummary")[0]
+        tf = pkg_summary.attr("totalFiles")
+        fwv = pkg_summary.attr("filesWithViolations")
+        p1_count = pkg_summary.attr("priority1")
+        p2_count = pkg_summary.attr("priority2")
+        p3_count = pkg_summary.attr("priority3")
+        summary = "CodeNarc scanned #{tf} files. Found #{fwv} files with violations. #{p1_count} P1 violations, #{p2_count} P2 violations, and #{p3_count} P3 violations"
+        message(summary, sticky: sticky_summary)
+      end
 
       # Iterate Packages
       doc.xpath("//Package").each do |pack_el|


### PR DESCRIPTION
## Description
In some cases the CodeNarc report does not contain the `PackageSummary` attribute. For instance when generated with https://github.com/nebula-plugins/gradle-lint-plugin.
It can be also convenient skip the summary posted by Danger on the PR.

## Change
* Add an attribute to be able skip summary.
* Set accessor usable